### PR TITLE
Run Powershell modules on Windows containers

### DIFF
--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -75,7 +75,11 @@ class Connection(ConnectionBase):
         # error it probably means that docker on their system is only
         # configured to be connected to by root and they are not running as
         # root.
-
+        
+        # Windows uses Powershell modules
+        if getattr(self._shell, "_IS_WINDOWS", False):
+            self.module_implementation_preferences = ('.ps1', '.exe', '')
+            
         if 'docker_command' in kwargs:
             self.docker_cmd = kwargs['docker_command']
         else:


### PR DESCRIPTION
##### SUMMARY
Currently, while executing an Ansible role against windows containers via docker connection plugin, Ansible runs the python modules instead of Powershell modules. We found this limitation, especially while executing `win_copy` task.
Hence, adding a commit that enables ansible to run Powershell modules on windows container via docker connection. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Docker connection plugin (lib/ansible/plugins/connection/docker.py)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
